### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/coffee.yml
+++ b/.github/workflows/coffee.yml
@@ -29,7 +29,7 @@ jobs:
       run: /bin/bash build.sh
 
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: m208/xmatrixstudio-coffee
         tags: latest

--- a/.github/workflows/violet.yml
+++ b/.github/workflows/violet.yml
@@ -33,7 +33,7 @@ jobs:
         CMD ["node", "index.js"]
 
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: m208/xmatrixstudio-violet-server
         tags: "2.0"


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore